### PR TITLE
Add chromem-go to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [USearch - Smaller & Faster Vector Search Engine for C++, Python, JavaScript, Rust, Java, GoLang, Wolfram](https://github.com/unum-cloud/usearch)
 - [Golang vector stores collection - Chroma, PGVector interfaces](https://github.com/urjitbhatia/vectorstores)
 - [Scalable Vector Search (SVS) - A performance library for vector similarity search](https://github.com/IntelLabs/ScalableVectorSearch)
+- [chromem-go - Embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence.](https://github.com/philippgille/chromem-go)
 
 ### Cloud Service
 


### PR DESCRIPTION
Hi 👋 , thanks for creating and maintaining this overview! I've been working on [chromem-go](https://github.com/philippgille/chromem-go), which differs from most other vector databases in that it's embeddable in Go (no client-server model, no CGO). I'd be very happy if it can be added to this awesome list!