### PR TITLE
Add VelesDB to Standalone Service section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [Vexvault - 100% browser based, open source, scalable, simple, zero-cost vector search](https://github.com/Xyntopia/vexvault)
 - [Vespa.ai - Text search engine and ... fast approximate vector search (ANN)](https://github.com/vespa-engine) 
 - [Vespa's large-scale ANN search using HNSW-IF indexes is described here](https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/)
+- [VelesDB - The SQLite of vector search. 70µs queries (700x faster than pgvector), ≥95% recall guaranteed, hybrid BM25+vector, native HNSW with AVX-512 SIMD, full ecosystem integrations and more.](https://github.com/cyberlife-coder/VelesDB)
 
 ### Library
 - [LangStream - LangStream is an open-source project that combines the best of event-based architectures with the latest Gen AI technologies.](https://langstream.ai)


### PR DESCRIPTION
# Pull Request: Add VelesDB to the list

## Title
Add VelesDB to Standalone Service section

## Description

Hello! I would like to add VelesDB to the Standalone Service section.

**VelesDB** is an embedded vector database with a focus on low-latency search and hybrid retrieval.

### Key features

- HNSW index with SIMD acceleration (AVX-512/AVX2/NEON)
- Hybrid BM25 + vector search in one query
- 70µs p50 search latency
- Configurable recall modes (Fast/Balanced/Perfect)
- REST API server + embedded library mode
- WASM, mobile (iOS/Android), and desktop (Tauri) support

### Installation

```bash
# Server
cargo install velesdb-server

# Python
pip install velesdb

# TypeScript
npm i @wiscale/velesdb

# WASM
npm i @wiscale/velesdb-wasm
```

Documentation: https://deepwiki.com/cyberlife-coder/VelesDB

I have placed it at the end of the section following the existing order.

Thanks for maintaining this list!
