### PR TITLE
Add Dakera: self-hosted HNSW vector memory server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [Vexvault - 100% browser based, open source, scalable, simple, zero-cost vector search](https://github.com/Xyntopia/vexvault)
 - [Vespa.ai - Text search engine and ... fast approximate vector search (ANN)](https://github.com/vespa-engine) 
 - [Vespa's large-scale ANN search using HNSW-IF indexes is described here](https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/)
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with HNSW approximate nearest neighbor search and RocksDB persistence. Decay-weighted retrieval, MCP-native, multi-agent namespacing.
 
 ### Library
 - [LangStream - LangStream is an open-source project that combines the best of event-based architectures with the latest Gen AI technologies.](https://langstream.ai)


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Standalone Service** section.

## Why

Dakera is a self-hosted vector memory server purpose-built for AI agents. It fits this list as a production-ready HNSW ANN search server with RocksDB persistence, decay-weighted retrieval, MCP-native interface, and multi-agent namespacing. It complements existing entries like Qdrant and Chroma but is specifically designed for agent memory workloads rather than general-purpose vector search.

## Entry added

```
- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with HNSW approximate nearest neighbor search and RocksDB persistence. Decay-weighted retrieval, MCP-native, multi-agent namespacing.
```