### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@
 - [Redis Cloud - Managed vector database in Redis](https://redis.com/cloud)
 - [Zilliz Cloud - Cloud-native service for Milvus](https://zilliz.com/cloud)
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for AI agent trust scoring on Solana. Zero-install Streamable HTTP endpoint for agent identity resolution, on-chain scoring, and signed trust receipts.
+
 ### Research Papers
 
 List of methods on how approximate vector search algorithm can be implemented more effciently.


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server for AI agent trust scoring on Solana.

Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

Free: resolve_agent, score_agent, preflight_check, verify_trust_receipt  
Paid: get_trust_receipt (x402, <1s Solana settlement)