### PR TITLE
Add altor-vec: 54KB WASM HNSW vector search running in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Embeddinghub - A database built for machine learning embeddings](https://github.com/featureform/embeddinghub)
 - [Hora - Efficient approximate nearest neighbor search algorithm collections library written in Rust](https://github.com/hora-search/hora)
 - [Voy - A WASM vector similarity search engine written in Rust](https://github.com/tantaraio/voy)
+- [altor-vec - In-browser HNSW vector search in JavaScript. 54KB WASM, sub-millisecond queries, no server required. npm install altor-vec](https://github.com/altor-lab/altor-vec)
 - [Chroma - The open-source embedding database for building LLM apps in Python or JavaScript with memory](https://github.com/chroma-core/chroma)
 - [USearch - Smaller & Faster Vector Search Engine for C++, Python, JavaScript, Rust, Java, GoLang, Wolfram](https://github.com/unum-cloud/usearch)
 - [Golang vector stores collection - Chroma, PGVector interfaces](https://github.com/urjitbhatia/vectorstores)


### PR DESCRIPTION
**altor-vec** is a client-side HNSW vector search engine compiled to 54KB of WASM. It runs entirely in the browser — no server, no API keys, no per-query cost.

- Sub-millisecond query latency at 10K vectors (0.6ms p95)
- 95.4% recall@10 measured on 10K documents (384d)
- MIT licensed, TypeScript types included
- Works in React, Vue, Next.js, or vanilla JS
- npm: `npm install altor-vec`
- GitHub: https://github.com/Altor-lab/altor-vec
- Docs: https://altorlab.dev

Added it after Voy (both are Rust-compiled WASM ANN libraries for JavaScript).