### PR TITLE
Add ferrovec to Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [Embeddinghub - A database built for machine learning embeddings](https://github.com/featureform/embeddinghub)
 - [Hora - Efficient approximate nearest neighbor search algorithm collections library written in Rust](https://github.com/hora-search/hora)
 - [Voy - A WASM vector similarity search engine written in Rust](https://github.com/tantaraio/voy)
+- [ferrovec - Dependency-light HNSW vector search in Rust compiled to WebAssembly, with OPFS persistence for private in-browser semantic search](https://github.com/singhpratech/ferrovec)
 - [altor-vec - In-browser HNSW vector search in JavaScript. 54KB WASM, sub-millisecond queries, no server required. npm install altor-vec](https://github.com/altor-lab/altor-vec)
 - [Chroma - The open-source embedding database for building LLM apps in Python or JavaScript with memory](https://github.com/chroma-core/chroma)
 - [USearch - Smaller & Faster Vector Search Engine for C++, Python, JavaScript, Rust, Java, GoLang, Wolfram](https://github.com/unum-cloud/usearch)


### PR DESCRIPTION
Adding **[ferrovec](https://github.com/singhpratech/ferrovec)** to the Library section.

A dependency-light HNSW vector index written in Rust, compiled to WebAssembly for in-browser semantic search: OPFS persistence (survives reloads), incremental upsert/remove + compaction, cross-tab single-writer coordination, and a three-line browser API over transformers.js embeddings. Also runs natively as a plain crate. ~33 KB gzipped wasm, MIT, on crates.io and npm. Live demo: https://singhpratech.github.io/ferrovec/demo.html