### PR TITLE
Add Samyama Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Vexvault - 100% browser based, open source, scalable, simple, zero-cost vector search](https://github.com/Xyntopia/vexvault)
 - [Vespa.ai - Text search engine and ... fast approximate vector search (ANN)](https://github.com/vespa-engine) 
 - [Vespa's large-scale ANN search using HNSW-IF indexes is described here](https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/)
+- [Samyama Graph - Rust graph-vector database combining property-graph traversal (~90% openCypher) with HNSW vector search in one engine](https://github.com/samyama-ai/samyama-graph)
 
 ### Library
 - [LangStream - LangStream is an open-source project that combines the best of event-based architectures with the latest Gen AI technologies.](https://langstream.ai)


### PR DESCRIPTION
Adds [samyama-ai/samyama-graph](https://github.com/samyama-ai/samyama-graph), an Apache-2.0 graph-vector database written in Rust: property-graph traversal with ~90% openCypher coverage and HNSW vector search in a single engine.

- Repo: https://github.com/samyama-ai/samyama-graph — 78 stars, actively developed, v1.7.0 released 2026-07-21
- License: Apache-2.0
- Docs: https://graph.samyama.cloud/book/
- openCypher coverage is deliberately described as *~90%*; the known gaps are documented in [docs/CYPHER_COMPATIBILITY.md](https://github.com/samyama-ai/samyama-graph/blob/main/docs/CYPHER_COMPATIBILITY.md).

Entry placed in **Standalone Service**, following the surrounding formatting. Disclosure: I work with the team behind this project. Happy to adjust the wording or placement.
